### PR TITLE
Structured data rewrite

### DIFF
--- a/applink/schema.go
+++ b/applink/schema.go
@@ -1,0 +1,41 @@
+// Package implementing applink, documented here: http://applinks.org/documentation/
+package applink
+
+import "net/url"
+
+type Ios struct {
+	Url *url.URL `json:"url"`
+	// The only evidence i have that this is a string is here:
+	// https://github.com/BoltsFramework/Bolts-iOS/blob/b72d5f2d6e0c418beea0a48da540a9eaf0768c0b/Bolts/iOS/BFAppLinkTarget.h#L28
+	AppStoreId string `json:"app_store_id,omitempty"`
+	AppName    string `json:"app_name,omitempty"`
+}
+
+type Android struct {
+	Url     *url.URL `json:"url,omitempty"`
+	Package string   `json:"package"`
+	Class   string   `json:"class,omitempty"`
+	AppName string   `json:"app_name,omitempty"`
+}
+
+type Windows struct {
+	Url     *url.URL `json:"url"`
+	AppId   string   `json:"app_id,omitempty"`
+	AppName string   `json:"app_name,omitempty"`
+}
+
+type Web struct {
+	Url            *url.URL `json:"url,omitempty"`
+	ShouldFallback bool     `json:"should_fallback,omitempty"`
+}
+
+type AppLink struct {
+	Ios              *Ios     `json:"ios,omitempty"`
+	Iphone           *Ios     `json:"iphone,omitempty"`
+	Ipad             *Ios     `json:"ipad,omitempty"`
+	Android          *Android `json:"android,omitempty"`
+	WindowsPhone     *Windows `json:"windows_phone,omitempty"`
+	Windows          *Windows `json:"windows,omitempty"`
+	WindowsUniversal *Windows `json:"windows_universal,omitempty"`
+	Web              *Web
+}

--- a/applink/schema.go
+++ b/applink/schema.go
@@ -1,41 +1,56 @@
 // Package implementing applink, documented here: http://applinks.org/documentation/
 package applink
 
-import "net/url"
-
 type Ios struct {
-	Url *url.URL `json:"url"`
+	Url string `json:"url" ogtag:"al:ios:url"`
 	// The only evidence i have that this is a string is here:
 	// https://github.com/BoltsFramework/Bolts-iOS/blob/b72d5f2d6e0c418beea0a48da540a9eaf0768c0b/Bolts/iOS/BFAppLinkTarget.h#L28
-	AppStoreId string `json:"app_store_id,omitempty"`
-	AppName    string `json:"app_name,omitempty"`
+	AppStoreId string `json:"app_store_id,omitempty" ogtag:"al:ios:app_store_id"`
+	AppName    string `json:"app_name,omitempty" ogtag:"al:ios:app_name"`
+}
+
+type Iphone struct {
+	Url string `json:"url" ogtag:"al:iphone:url"`
+	// The only evidence i have that this is a string is here:
+	// https://github.com/BoltsFramework/Bolts-iOS/blob/b72d5f2d6e0c418beea0a48da540a9eaf0768c0b/Bolts/iOS/BFAppLinkTarget.h#L28
+	AppStoreId string `json:"app_store_id,omitempty" ogtag:"al:iphone:app_store_id"`
+	AppName    string `json:"app_name,omitempty" ogtag:"al:iphone:app_name"`
+}
+
+type Ipad struct {
+	Url string `json:"url" ogtag:"al:ipad:url"`
+	// The only evidence i have that this is a string is here:
+	// https://github.com/BoltsFramework/Bolts-iOS/blob/b72d5f2d6e0c418beea0a48da540a9eaf0768c0b/Bolts/iOS/BFAppLinkTarget.h#L28
+	AppStoreId string `json:"app_store_id,omitempty" ogtag:"al:ipad:app_store_id"`
+	AppName    string `json:"app_name,omitempty" ogtag:"al:ipad:app_name"`
 }
 
 type Android struct {
-	Url     *url.URL `json:"url,omitempty"`
-	Package string   `json:"package"`
-	Class   string   `json:"class,omitempty"`
-	AppName string   `json:"app_name,omitempty"`
+	Url     string `json:"url,omitempty" ogtag:"al:android:url"`
+	Package string `json:"package,omitempty"`
+	Class   string `json:"class,omitempty"`
+	AppName string `json:"app_name,omitempty"`
 }
 
 type Windows struct {
-	Url     *url.URL `json:"url"`
-	AppId   string   `json:"app_id,omitempty"`
-	AppName string   `json:"app_name,omitempty"`
+	Url     string `json:"url"`
+	AppId   string `json:"app_id,omitempty"`
+	AppName string `json:"app_name,omitempty"`
 }
 
 type Web struct {
-	Url            *url.URL `json:"url,omitempty"`
-	ShouldFallback bool     `json:"should_fallback,omitempty"`
+	Url            string `json:"url,omitempty"`
+	ShouldFallback bool   `json:"should_fallback,omitempty"`
 }
 
 type AppLink struct {
-	Ios              *Ios     `json:"ios,omitempty"`
-	Iphone           *Ios     `json:"iphone,omitempty"`
-	Ipad             *Ios     `json:"ipad,omitempty"`
-	Android          *Android `json:"android,omitempty"`
+	Ios     *Ios     `json:"ios,omitempty" ogtag:",fill"`
+	Iphone  *Iphone  `json:"iphone,omitempty" ogtag:",fill"`
+	Ipad    *Ipad    `json:"ipad,omitempty" ogtag:",fill"`
+	Android *Android `json:"android,omitempty" ogtag:",fill"`
+	// TODO: Windows/web support
 	WindowsPhone     *Windows `json:"windows_phone,omitempty"`
 	Windows          *Windows `json:"windows,omitempty"`
 	WindowsUniversal *Windows `json:"windows_universal,omitempty"`
-	Web              *Web
+	Web              *Web     `json:"web,omitempty"`
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net/http"
@@ -50,9 +51,11 @@ func main() {
 			fmt.Printf("Could not fetch: %s\n", err)
 			return
 		}
-		for prop, val := range tags {
-			fmt.Printf("%s -- %s\n", prop, val)
+		jsonTags, err := json.MarshalIndent(tags, "", "\t")
+		if err != nil {
+			fmt.Printf("Could not marshal json: %s\n", err)
 		}
+		fmt.Println(jsonTags)
 	} else {
 		panic("Need to use this properly and I need to print usage info!")
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ func main() {
 		if err != nil {
 			fmt.Printf("Could not marshal json: %s\n", err)
 		}
-		fmt.Println(jsonTags)
+		fmt.Println(string(jsonTags))
 	} else {
 		panic("Need to use this properly and I need to print usage info!")
 	}

--- a/gogetter.go
+++ b/gogetter.go
@@ -34,12 +34,13 @@ type Scraper struct {
 }
 
 var tagAliases = map[string][]string{
-	"og:description": {"twitter:description", "description"},
-	"og:title":       {"twitter:title", "title"},
-	"og:image":       {"twitter:image"},
-	"al:iphone:url":  {"twitter:app:url:iphone"},
-	"al:ipad:url":    {"twitter:app:url:ipad"},
-	"al:android:url": {"twitter:app:url:googleplay"},
+	"og:description":         {"twitter:description", "description"},
+	"og:title":               {"twitter:title", "title"},
+	"og:image":               {"twitter:image"},
+	"al:iphone:url":          {"twitter:app:url:iphone"},
+	"al:ipad:url":            {"twitter:app:url:ipad"},
+	"al:android:url":         {"twitter:app:url:googleplay"},
+	"article:published_time": {"article:published"},
 }
 
 // Finds other names for the same value and puts it in the map
@@ -107,19 +108,14 @@ func convertTagsToCard(tags map[string]string, webUrl string) (wildcard.Wildcard
 		ogType = "website"
 	}
 	var card wildcard.Wildcard
+	url, ok := tags["og:url"]
+	if !ok {
+		url = webUrl
+	}
 	switch ogType {
-	/*
-		case "video.episode":
-			fallthrough
-		case "video.movie":
-			fallthrough
-		case "video.other":
-	*/
+	case "article":
+		card = wildcard.NewArticleCard(webUrl, url)
 	default:
-		url, ok := tags["og:url"]
-		if !ok {
-			url = webUrl
-		}
 		card = wildcard.NewLinkCard(webUrl, url)
 	}
 	err := recursivelyDecode(tags, card)

--- a/gogetter.go
+++ b/gogetter.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/JustinTulloss/gogetter/wildcard"
 	"github.com/PuerkitoBio/goquery"
 	"github.com/facebookgo/httpcontrol"
 	"github.com/temoto/robotstxt.go"
@@ -102,7 +103,7 @@ func (s *Scraper) ParseTags(r io.Reader) (map[string]string, error) {
 	return results, nil
 }
 
-func (s *Scraper) ScrapeTags(url string) (map[string]string, error) {
+func (s *Scraper) ScrapeTags(url string) (interface{}, error) {
 	permitted, err := s.checkRobotsTxt(url)
 	if err != nil {
 		return nil, err
@@ -130,6 +131,10 @@ func (s *Scraper) ScrapeTags(url string) (map[string]string, error) {
 		fallthrough
 	case strings.Contains(contentType, "text/html"):
 		return s.ParseTags(resp.Body)
+	case strings.HasPrefix(contentType, "image"):
+		card := wildcard.NewImageCard(url, url)
+		card.Media.ImageContentType = contentType
+		return card, nil
 	default:
 		// We can't really trust the Content-Type header, so we take
 		// a look at what actually gets returned.

--- a/gogetter.go
+++ b/gogetter.go
@@ -62,6 +62,7 @@ func resolveAliases(tags map[string]string) {
 	}
 }
 
+// Used by recusivelyDecode to look at every field in a struct
 func iterateOverFields(value reflect.Value, tags map[string]string) error {
 	for i := 0; i < value.NumField(); i++ {
 		field := value.Field(i)
@@ -84,6 +85,11 @@ func iterateOverFields(value reflect.Value, tags map[string]string) error {
 	return nil
 }
 
+// This is a hacky way of transferring a flat map of tags to values into a
+// nested structure. Since each leaf in the structure has a unique key in the
+// flat map, we can just iterate through every struct that might potentially
+// have tags (as indicated by the `ogtag` struct tag) and try to match the
+// tags to the fields using mapstructure.
 func recursivelyDecode(tags map[string]string, result interface{}) error {
 	decoderConfig := &mapstructure.DecoderConfig{
 		WeaklyTypedInput: true,

--- a/gogetter.go
+++ b/gogetter.go
@@ -34,13 +34,14 @@ type Scraper struct {
 }
 
 var tagAliases = map[string][]string{
-	"og:description":         {"twitter:description", "description"},
-	"og:title":               {"twitter:title", "title"},
-	"og:image":               {"twitter:image"},
-	"al:iphone:url":          {"twitter:app:url:iphone"},
-	"al:ipad:url":            {"twitter:app:url:ipad"},
 	"al:android:url":         {"twitter:app:url:googleplay"},
+	"al:ipad:url":            {"twitter:app:url:ipad"},
+	"al:iphone:url":          {"twitter:app:url:iphone"},
 	"article:published_time": {"article:published"},
+	"og:description":         {"twitter:description", "description"},
+	"og:image":               {"twitter:image"},
+	"og:site_name":           {"cre"},
+	"og:title":               {"twitter:title", "title"},
 }
 
 // Finds other names for the same value and puts it in the map
@@ -163,6 +164,8 @@ func (s *Scraper) checkRobotsTxt(fullUrl string) (bool, error) {
 	return robots.TestAgent(original, s.useragent), nil
 }
 
+var rawMetaTags = []string{"cre"}
+
 func (s *Scraper) ParseTags(r io.Reader, url string) (wildcard.Wildcard, error) {
 	doc, err := goquery.NewDocumentFromReader(r)
 	if err != nil {
@@ -181,6 +184,9 @@ func (s *Scraper) ParseTags(r io.Reader, url string) (wildcard.Wildcard, error) 
 	}
 	// Find all meta tags for all different og prefixes we support
 	tags := doc.Find(`meta[name="description"]`)
+	for _, metaTag := range rawMetaTags {
+		tags = tags.Add(fmt.Sprintf(`meta[name="%s"]`, metaTag))
+	}
 	for _, prefix := range ogPrefixes {
 		tags = tags.Add(fmt.Sprintf(`meta[property^="%s:"]`, prefix))
 		tags = tags.Add(fmt.Sprintf(`meta[name^="%s:"]`, prefix))

--- a/gogetter_test.go
+++ b/gogetter_test.go
@@ -1,12 +1,20 @@
 package gogetter
 
-import "reflect"
+import (
+	"reflect"
+
+	"github.com/JustinTulloss/gogetter/applink"
+	"github.com/JustinTulloss/gogetter/wildcard"
+)
 import "strings"
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 type doctest struct {
 	doc  string
-	tags map[string]string
+	tags interface{}
 }
 
 var testdocs = []doctest{
@@ -17,36 +25,80 @@ var testdocs = []doctest{
 				<meta property="og:title" content="More interesting" />
 			</head>
 		</html>`,
-		map[string]string{
-			"og:title": "More interesting",
-			"title":    "Not interesting",
+		&wildcard.LinkCard{
+			Card: wildcard.Card{
+				CardType: wildcard.LinkType,
+			},
+			Target: &wildcard.LinkTarget{
+				GenericMetadata: wildcard.GenericMetadata{
+					Title: "More interesting",
+					AppLink: &applink.AppLink{
+						Ios:     &applink.Ios{},
+						Iphone:  &applink.Iphone{},
+						Ipad:    &applink.Ipad{},
+						Android: &applink.Android{},
+					},
+					Image:           &wildcard.ImageDetails{},
+					PublicationDate: &time.Time{},
+				},
+			},
 		},
 	},
 	{
 		`random gobbleygook
 		<title>not interesting</title>
 		<meta property="og:title" content="relevant" />`,
-		map[string]string{
-			"og:title": "relevant",
-			"title":    "not interesting",
+		&wildcard.LinkCard{
+			Card: wildcard.Card{
+				CardType: wildcard.LinkType,
+			},
+			Target: &wildcard.LinkTarget{
+				GenericMetadata: wildcard.GenericMetadata{
+					Title: "relevant",
+					AppLink: &applink.AppLink{
+						Ios:     &applink.Ios{},
+						Iphone:  &applink.Iphone{},
+						Ipad:    &applink.Ipad{},
+						Android: &applink.Android{},
+					},
+					Image:           &wildcard.ImageDetails{},
+					PublicationDate: &time.Time{},
+				},
+			},
 		},
 	},
-	{
-		`<meta property="twitter:hello" content="twitter works" />`,
-		map[string]string{
-			"twitter:hello": "twitter works",
-		},
-	},
-	{
-		`<meta property="airbedandbreakfast:test" content="airbnb works" />`,
-		map[string]string{
-			"airbedandbreakfast:test": "airbnb works",
-		},
-	},
+	/*
+			{
+				`<meta property="twitter:hello" content="twitter works" />`,
+				map[string]string{
+					"twitter:hello": "twitter works",
+				},
+			},
+		{
+			`<meta property="airbedandbreakfast:test" content="airbnb works" />`,
+			map[string]string{
+				"airbedandbreakfast:test": "airbnb works",
+			},
+		},*/
 	{
 		`<meta name="description" content="pod (plain old descriptions) work" />`,
-		map[string]string{
-			"description": "pod (plain old descriptions) work",
+		&wildcard.LinkCard{
+			Card: wildcard.Card{
+				CardType: wildcard.LinkType,
+			},
+			Target: &wildcard.LinkTarget{
+				Description: "pod (plain old descriptions) work",
+				GenericMetadata: wildcard.GenericMetadata{
+					AppLink: &applink.AppLink{
+						Ios:     &applink.Ios{},
+						Iphone:  &applink.Iphone{},
+						Ipad:    &applink.Ipad{},
+						Android: &applink.Android{},
+					},
+					Image:           &wildcard.ImageDetails{},
+					PublicationDate: &time.Time{},
+				},
+			},
 		},
 	},
 }
@@ -59,13 +111,13 @@ func TestParseTags(t *testing.T) {
 		t.Fail()
 	}
 	for _, doctest := range testdocs {
-		testresult, err := scraper.ParseTags(strings.NewReader(doctest.doc))
+		testresult, err := scraper.ParseTags(strings.NewReader(doctest.doc), "")
 		if err != nil {
 			t.Errorf(err.Error())
 		}
 		eq := reflect.DeepEqual(testresult, doctest.tags)
 		if !eq {
-			t.Errorf("%v != %v", testresult, doctest.tags)
+			t.Errorf("%#v != %#v", testresult, doctest.tags)
 		}
 	}
 }

--- a/wildcard/schema.go
+++ b/wildcard/schema.go
@@ -40,15 +40,17 @@ type Card struct {
 type GenericMetadata struct {
 	Title           string     `json:"title,omitempty" ogtag:"og:title"`
 	PublicationDate *time.Time `json:"publication_date,omitempty"`
-	Source          string     `json:"source,omitempty"`
+	Source          string     `json:"source,omitempty" ogtag:"og:site_name"`
 	Keywords        []string   `json:"keywords,omitempty"`
 
 	// Our own addition, wildcard has a neutered version
-	AppLink *applink.AppLink `json:"al,omitempty"`
+	AppLink *applink.AppLink `json:"app_link,omitempty" ogtag:",fill"`
 
 	// Our own addition, is usually the favicon
 	SourceIcon string `json:"source_icon,omitempty" ogtag:"favicon"`
-	ImageUrl   string `json:"image_url,omitempty" ogtag:"og:image"`
+
+	// Our own addition since why wouldn't everything have an image?
+	Image *ImageDetails `json:"image,omitempty" ogtag:",fill"`
 }
 
 type Article struct {
@@ -94,19 +96,23 @@ func NewVideoCard(originalUrl string) *VideoCard {
 	}
 }
 
-type ImageMedia struct {
-	Type     MediaType `json:"type"`
-	ImageUrl string    `json:"image_url"`
-
-	//Optional
-	ImageCaption    string `json:"image_caption,omitempty"`
-	Author          string `json:"author,omitempty"`
-	Width           int    `json:"width,omitempty"`
-	Height          int    `json:"height,omitempty"`
-	GenericMetadata `ogtag:",squash"`
+type ImageDetails struct {
+	ImageUrl string `json:"image_url" ogtag:"og:image"`
+	Width    int    `json:"width,omitempty" ogtag:"og:image:width"`
+	Height   int    `json:"height,omitempty" ogtag:"og:image:height"`
 
 	// Added by us
 	ImageContentType string `json:"image_content_type,omitempty"`
+}
+
+type ImageMedia struct {
+	Type MediaType `json:"type"`
+	ImageDetails
+
+	//Optional
+	ImageCaption string `json:"image_caption,omitempty"`
+	Author       string `json:"author,omitempty"`
+	GenericMetadata
 }
 
 type ImageCard struct {
@@ -121,8 +127,10 @@ func NewImageCard(originalUrl, src string) *ImageCard {
 			WebUrl:   originalUrl,
 		},
 		&ImageMedia{
-			Type:     ImageMediaType,
-			ImageUrl: src,
+			Type: ImageMediaType,
+			ImageDetails: ImageDetails{
+				ImageUrl: src,
+			},
 		},
 	}
 }
@@ -135,7 +143,7 @@ type LinkTarget struct {
 
 type LinkCard struct {
 	Card
-	Target *LinkTarget `json:"target"`
+	Target *LinkTarget `json:"target" ogtag:",fill"`
 }
 
 func NewLinkCard(originalUrl, linkUrl string) *LinkCard {

--- a/wildcard/schema.go
+++ b/wildcard/schema.go
@@ -14,8 +14,8 @@ const (
 	ArticleType       CardType = "article"
 	ImageType         CardType = "image"
 	LinkType          CardType = "link"
-	ProductType       CardType = "product"
 	ProductSearchType CardType = "product_search"
+	ProductType       CardType = "product"
 	ReviewType        CardType = "review"
 	VideoType         CardType = "video"
 )
@@ -27,6 +27,9 @@ const (
 	VideoMediaType MediaType = "video"
 )
 
+// Every card must implement this interface
+type Wildcard interface{}
+
 // Every card has these
 type Card struct {
 	CardType CardType `json:"card_type"`
@@ -35,7 +38,7 @@ type Card struct {
 
 // Metadata that pretty much every topic has
 type GenericMetadata struct {
-	Title           string     `json:"title,omitempty"`
+	Title           string     `json:"title,omitempty" ogtag:"og:title"`
 	PublicationDate *time.Time `json:"publication_date,omitempty"`
 	Source          string     `json:"source,omitempty"`
 	Keywords        []string   `json:"keywords,omitempty"`
@@ -44,14 +47,15 @@ type GenericMetadata struct {
 	AppLink *applink.AppLink `json:"al,omitempty"`
 
 	// Our own addition, is usually the favicon
-	SourceIcon string `json:"source_icon,omitempty"`
+	SourceIcon string `json:"source_icon,omitempty" ogtag:"favicon"`
+	ImageUrl   string `json:"image_url,omitempty" ogtag:"og:image"`
 }
 
 type Article struct {
 	AbstractContent string   `json:"abstract_content"`
 	IsBreaking      bool     `json:"is_breaking,omitempty"`
 	Contributors    []string `json:"contributors,omitempty"`
-	GenericMetadata
+	GenericMetadata `ogtag:",squash"`
 }
 
 type ArticleCard struct {
@@ -64,15 +68,15 @@ type VideoMedia struct {
 
 	// XXX: Perhaps pull these out for other embed types
 	EmbeddedUrl       string `json:"embedded_url"`
-	EmbeddedUrlWidth  string `json:"embedded_url_width"`
-	EmbeddedUrlHeight string `json:"embedded_url_height"`
+	EmbeddedUrlWidth  string `json:"embedded_url_width" ogtag:"og:video:width"`
+	EmbeddedUrlHeight string `json:"embedded_url_height" ogtag:"og:video:height"`
 
 	// Optional
-	StreamUrl         string `json:"stream_url,omitempty"`
-	StreamContentType string `json:"stream_content_type,omitempty"`
+	StreamUrl         string `json:"stream_url,omitempty" ogtag:"og:video:url"`
+	StreamContentType string `json:"stream_content_type,omitempty" ogtag:"og:video:type"`
 	PosterImageUrl    string `json:"poster_image_url,omitempty"`
 	Creator           string `json:"creator,omitempty"`
-	GenericMetadata
+	GenericMetadata   `ogtag:",squash"`
 }
 
 type VideoCard struct {
@@ -80,16 +84,26 @@ type VideoCard struct {
 	Media *VideoMedia `json:"media"`
 }
 
+func NewVideoCard(originalUrl string) *VideoCard {
+	return &VideoCard{
+		Card{
+			CardType: VideoType,
+			WebUrl:   originalUrl,
+		},
+		&VideoMedia{},
+	}
+}
+
 type ImageMedia struct {
 	Type     MediaType `json:"type"`
 	ImageUrl string    `json:"image_url"`
 
 	//Optional
-	ImageCaption string `json:"image_caption,omitempty"`
-	Author       string `json:"author,omitempty"`
-	Width        int    `json:"width,omitempty"`
-	Height       int    `json:"height,omitempty"`
-	GenericMetadata
+	ImageCaption    string `json:"image_caption,omitempty"`
+	Author          string `json:"author,omitempty"`
+	Width           int    `json:"width,omitempty"`
+	Height          int    `json:"height,omitempty"`
+	GenericMetadata `ogtag:",squash"`
 
 	// Added by us
 	ImageContentType string `json:"image_content_type,omitempty"`
@@ -109,6 +123,29 @@ func NewImageCard(originalUrl, src string) *ImageCard {
 		&ImageMedia{
 			Type:     ImageMediaType,
 			ImageUrl: src,
+		},
+	}
+}
+
+type LinkTarget struct {
+	Url             string `json:"url"`
+	Description     string `json:"description,omitempty" ogtag:"og:description"`
+	GenericMetadata `ogtag:",squash"`
+}
+
+type LinkCard struct {
+	Card
+	Target *LinkTarget `json:"target"`
+}
+
+func NewLinkCard(originalUrl, linkUrl string) *LinkCard {
+	return &LinkCard{
+		Card{
+			CardType: LinkType,
+			WebUrl:   originalUrl,
+		},
+		&LinkTarget{
+			Url: linkUrl,
 		},
 	}
 }

--- a/wildcard/schema.go
+++ b/wildcard/schema.go
@@ -1,0 +1,114 @@
+// Structs for wildcard schema, documnted here:
+// http://www.trywildcard.com/docs/schema/
+package wildcard
+
+import (
+	"time"
+
+	"github.com/JustinTulloss/gogetter/applink"
+)
+
+type CardType string
+
+const (
+	ArticleType       CardType = "article"
+	ImageType         CardType = "image"
+	LinkType          CardType = "link"
+	ProductType       CardType = "product"
+	ProductSearchType CardType = "product_search"
+	ReviewType        CardType = "review"
+	VideoType         CardType = "video"
+)
+
+type MediaType string
+
+const (
+	ImageMediaType MediaType = "image"
+	VideoMediaType MediaType = "video"
+)
+
+// Every card has these
+type Card struct {
+	CardType CardType `json:"card_type"`
+	WebUrl   string   `json:"web_url"`
+}
+
+// Metadata that pretty much every topic has
+type GenericMetadata struct {
+	Title           string     `json:"title,omitempty"`
+	PublicationDate *time.Time `json:"publication_date,omitempty"`
+	Source          string     `json:"source,omitempty"`
+	Keywords        []string   `json:"keywords,omitempty"`
+
+	// Our own addition, wildcard has a neutered version
+	AppLink *applink.AppLink `json:"al,omitempty"`
+
+	// Our own addition, is usually the favicon
+	SourceIcon string `json:"source_icon,omitempty"`
+}
+
+type Article struct {
+	AbstractContent string   `json:"abstract_content"`
+	IsBreaking      bool     `json:"is_breaking,omitempty"`
+	Contributors    []string `json:"contributors,omitempty"`
+	GenericMetadata
+}
+
+type ArticleCard struct {
+	Card
+	Article *Article
+}
+
+type VideoMedia struct {
+	Type MediaType `json:"type"`
+
+	// XXX: Perhaps pull these out for other embed types
+	EmbeddedUrl       string `json:"embedded_url"`
+	EmbeddedUrlWidth  string `json:"embedded_url_width"`
+	EmbeddedUrlHeight string `json:"embedded_url_height"`
+
+	// Optional
+	StreamUrl         string `json:"stream_url,omitempty"`
+	StreamContentType string `json:"stream_content_type,omitempty"`
+	PosterImageUrl    string `json:"poster_image_url,omitempty"`
+	Creator           string `json:"creator,omitempty"`
+	GenericMetadata
+}
+
+type VideoCard struct {
+	Card
+	Media *VideoMedia `json:"media"`
+}
+
+type ImageMedia struct {
+	Type     MediaType `json:"type"`
+	ImageUrl string    `json:"image_url"`
+
+	//Optional
+	ImageCaption string `json:"image_caption,omitempty"`
+	Author       string `json:"author,omitempty"`
+	Width        int    `json:"width,omitempty"`
+	Height       int    `json:"height,omitempty"`
+	GenericMetadata
+
+	// Added by us
+	ImageContentType string `json:"image_content_type,omitempty"`
+}
+
+type ImageCard struct {
+	Card
+	Media *ImageMedia `json:"media"`
+}
+
+func NewImageCard(originalUrl, src string) *ImageCard {
+	return &ImageCard{
+		Card{
+			CardType: ImageType,
+			WebUrl:   originalUrl,
+		},
+		&ImageMedia{
+			Type:     ImageMediaType,
+			ImageUrl: src,
+		},
+	}
+}

--- a/wildcard/schema.go
+++ b/wildcard/schema.go
@@ -1,4 +1,4 @@
-// Structs for wildcard schema, documnted here:
+// Structs for wildcard schema, documented here:
 // http://www.trywildcard.com/docs/schema/
 package wildcard
 

--- a/wildcard/schema.go
+++ b/wildcard/schema.go
@@ -39,7 +39,7 @@ type Card struct {
 // Metadata that pretty much every topic has
 type GenericMetadata struct {
 	Title           string     `json:"title,omitempty" ogtag:"og:title"`
-	PublicationDate *time.Time `json:"publication_date,omitempty"`
+	PublicationDate *time.Time `json:"publication_date,omitempty" ogtag:"article:published_time"`
 	Source          string     `json:"source,omitempty" ogtag:"og:site_name"`
 	Keywords        []string   `json:"keywords,omitempty"`
 
@@ -54,7 +54,7 @@ type GenericMetadata struct {
 }
 
 type Article struct {
-	AbstractContent string   `json:"abstract_content"`
+	AbstractContent string   `json:"abstract_content" ogtag:"og:description"`
 	IsBreaking      bool     `json:"is_breaking,omitempty"`
 	Contributors    []string `json:"contributors,omitempty"`
 	GenericMetadata `ogtag:",squash"`
@@ -62,7 +62,17 @@ type Article struct {
 
 type ArticleCard struct {
 	Card
-	Article *Article
+	Article *Article `json:"article" ogtag:",fill"`
+}
+
+func NewArticleCard(webUrl, articleUrl string) *ArticleCard {
+	return &ArticleCard{
+		Card{
+			CardType: ArticleType,
+			WebUrl:   webUrl,
+		},
+		&Article{},
+	}
 }
 
 type VideoMedia struct {


### PR DESCRIPTION
This is a pretty big rework of gogetter.

Instead of being a raw scraper of open graph values, this now tries to understand the metadata of the pages that its looking at and returns the data in a consistent schema.

The schema is based on [wildcard's](http://www.trywildcard.com/docs/schema/), with additions and changes as it makes sense.
